### PR TITLE
include RELEASE.$(EPICS_HOST_ARCH).local

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -39,4 +39,5 @@ EPICS_BASE = /home/ralph/work/EPICS/V3/3.16
 # These allow developers to override the RELEASE variable settings
 # without having to modify the configure/RELEASE file itself.
 -include $(TOP)/../RELEASE.local
+-include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
 -include $(TOP)/configure/RELEASE.local


### PR DESCRIPTION
Just like other modules bundled in epics base. Because this file
is automatcally created, it eases the conventional build of PCAS
as part of epics base.