### PR TITLE
Ip ignore as ipag

### DIFF
--- a/src/pcas/generic/casChannel.cc
+++ b/src/pcas/generic/casChannel.cc
@@ -13,7 +13,10 @@
  *              505 665 1831
  */
 
+#include <epicsVersion.h>
+
 #define epicsExportSharedSymbols
+#include <epicsTypes.h>
 #include "casdef.h"
 #include "casChannelI.h"
 
@@ -47,7 +50,11 @@ casPV * casChannel::getPV ()
 }
 
 void casChannel::setOwner ( const char * const /* pUserName */, 
-	const char * const /* pHostName */ )
+	                    const char * const /* pHostName */
+#ifdef EPICS_HAS_AS_IPAG
+	                    ,epicsUInt32 ip_addr
+#endif
+                          )
 {
 	//
 	// NOOP

--- a/src/pcas/generic/casChannelI.h
+++ b/src/pcas/generic/casChannelI.h
@@ -16,6 +16,9 @@
 #ifndef casChannelIh
 #define casChannelIh
 
+#include <epicsVersion.h>
+
+#include <epicsTypes.h>
 #include "casPVI.h"
 #include "casEvent.h"
 #include "chanIntfForPV.h"
@@ -46,7 +49,11 @@ public:
     const gddEnumStringTable & enumStringTable () const;
     ca_uint32_t getMaxElem () const;
     void setOwner ( const char * const pUserName, 
-        const char * const pHostName );
+                    const char * const pHostName
+#ifdef EPICS_HAS_AS_IPAG
+                    ,epicsUInt32 ip_addr
+#endif
+                  );
     bool readAccess () const;
     bool writeAccess () const;
     bool confirmationRequested () const;
@@ -114,9 +121,17 @@ inline void casChannelI::clearOutstandingReads ()
 }
 
 inline void casChannelI::setOwner ( const char * const pUserName, 
-    const char * const pHostName )
+                                    const char * const pHostName
+#ifdef EPICS_HAS_AS_IPAG
+                                    ,epicsUInt32 ip_addr
+#endif
+                                  )
 {
-    this->chan.setOwner ( pUserName, pHostName );
+    this->chan.setOwner ( pUserName, pHostName
+#ifdef EPICS_HAS_AS_IPAG
+                          ,ip_addr 
+#endif
+                        );
 }
 
 inline bool casChannelI::readAccess () const

--- a/src/pcas/generic/casPV.cc
+++ b/src/pcas/generic/casPV.cc
@@ -13,7 +13,10 @@
  *              505 665 1831
  */
 
+#include <epicsVersion.h>
+
 #define epicsExportSharedSymbols
+#include <epicsTypes.h>
 #include "casPVI.h"
 
 casPV::casPV () : 
@@ -58,7 +61,11 @@ void casPV::destroy ()
 // casPV::createChannel()
 //
 casChannel *casPV::createChannel (
-    const casCtx &ctx, const char * const, const char * const )
+    const casCtx &ctx, const char * const, const char * const
+#ifdef EPICS_HAS_AS_IPAG
+    ,epicsUInt32 ip_addr
+#endif
+    )
 {
 	return new casChannel ( ctx );
 }

--- a/src/pcas/generic/casPVI.cc
+++ b/src/pcas/generic/casPVI.cc
@@ -12,6 +12,10 @@
  *              505 665 1831
  */
 
+#include <epicsVersion.h>
+
+#include <epicsTypes.h>
+
 #include "epicsGuard.h"
 #include "gddAppTable.h" // EPICS application type table
 #include "gddApps.h"
@@ -499,11 +503,19 @@ caStatus casPVI::writeNotify ( const casCtx & ctx, const gdd & value )
 }
 
 casChannel * casPVI::createChannel ( const casCtx & ctx,
-    const char * const pUserName, const char * const pHostName )
+    const char * const pUserName, const char * const pHostName
+#ifdef EPICS_HAS_AS_IPAG
+    ,epicsUInt32 ip_addr
+#endif
+    )
 {
     epicsGuard < epicsMutex > guard ( this->mutex );
     if ( this->pPV ) {
-        return this->pPV->createChannel ( ctx, pUserName, pHostName );
+        return this->pPV->createChannel ( ctx, pUserName, pHostName
+#ifdef EPICS_HAS_AS_IPAG
+                                          ,ip_addr
+#endif
+                                        );
     }
     else {
         return 0;

--- a/src/pcas/generic/casPVI.h
+++ b/src/pcas/generic/casPVI.h
@@ -16,10 +16,14 @@
 #ifndef casPVIh
 #define casPVIh
 
+#include <epicsVersion.h>
+
 #ifdef epicsExportSharedSymbols
 #   define epicsExportSharedSymbols_casPVIh
 #   undef epicsExportSharedSymbols
 #endif
+
+#include <epicsTypes.h>
 
 // external headers included here
 #include "tsSLList.h"
@@ -77,7 +81,11 @@ public:
     caStatus write ( const casCtx & ctx, const gdd & value );
     caStatus writeNotify ( const casCtx & ctx, const gdd & value );
     casChannel * createChannel ( const casCtx & ctx,
-        const char * const pUserName, const char * const pHostName );
+        const char * const pUserName, const char * const pHostName
+#ifdef EPICS_HAS_AS_IPAG
+        ,epicsUInt32 ip_addr
+#endif
+        );
     aitEnum bestExternalType () const;
     const char * getName () const;
     void casPVDestroyNotify ();

--- a/src/pcas/generic/casStrmClient.h
+++ b/src/pcas/generic/casStrmClient.h
@@ -10,10 +10,14 @@
 #ifndef casStrmClienth
 #define casStrmClienth
 
+#include <epicsVersion.h>
+
 #ifdef epicsExportSharedSymbols
 #   define epicsExportSharedSymbols_casStrmClienth
 #   undef epicsExportSharedSymbols
 #endif
+
+#include <epicsTypes.h>
 
 #include "epicsTime.h"
 
@@ -61,6 +65,9 @@ private:
     caNetAddr _clientAddr;
     char * pUserName;
     char * pHostName;
+#ifdef EPICS_HAS_AS_IPAG
+    epicsUInt32 ip_addr;
+#endif
     smartGDDPointer pValueRead;
     unsigned incommingBytesToDrain;
     caStatus pendingResponseStatus;

--- a/src/pcas/generic/casdef.h
+++ b/src/pcas/generic/casdef.h
@@ -18,6 +18,8 @@
 #ifndef includecasdefh
 #define includecasdefh
 
+#include <epicsVersion.h>
+
 #ifdef epicsExportSharedSymbols
 #   define epicsExportSharedSymbols_casdefh
 #   undef epicsExportSharedSymbols
@@ -26,6 +28,8 @@
 //
 // EPICS
 //
+#include <epicsTypes.h>
+
 #include "errMdef.h"            // EPICS error codes 
 #include "gdd.h"                // EPICS data descriptors 
 #include "alarm.h"              // EPICS alarm severity/condition 
@@ -428,7 +432,11 @@ public:
     // (or a derived class) each time that this routine is called
     //
     virtual casChannel * createChannel ( const casCtx &ctx,
-        const char * const pUserName, const char * const pHostName );
+        const char * const pUserName, const char * const pHostName
+#ifdef EPICS_HAS_AS_IPAG
+        ,epicsUInt32 ip_addr
+#endif
+        );
     
     //
     // tbe best type for clients to use when accessing the
@@ -577,7 +585,11 @@ public:
     // for a live connection.
     //
     virtual void setOwner ( const char * const pUserName, 
-        const char * const pHostName );
+                            const char * const pHostName
+#ifdef EPICS_HAS_AS_IPAG
+                            ,epicsUInt32 ip_addr
+#endif
+                            );
 
     //
     // the following are encouraged to change during an channel's

--- a/src/pcas/io/bsdSocket/casDGIntfIO.cc
+++ b/src/pcas/io/bsdSocket/casDGIntfIO.cc
@@ -16,6 +16,8 @@
 // Should I fetch the MTU from the outgoing interface?
 //
 
+#include <epicsVersion.h>
+
 #include "addrList.h"
 #include "errlog.h"
 
@@ -41,7 +43,6 @@ static void  forcePort (ELLLIST *pList, unsigned short port)
     }
 }
 
-
 casDGIntfIO::casDGIntfIO ( caServerI & serverIn, clientBufMemoryManager & memMgr,
     const caNetAddr & addr, bool autoBeaconAddr, bool addConfigBeaconAddr ) :
     casDGClient ( serverIn, memMgr )
@@ -54,6 +55,9 @@ casDGIntfIO::casDGIntfIO ( caServerI & serverIn, clientBufMemoryManager & memMgr
     
     ellInit ( &BCastAddrList );
     ellInit ( &this->beaconAddrList );
+#ifdef EPICS_HAS_CAS_IGNORE_NET_LIST
+    ignoreNets= NULL;
+#endif
     
     if ( ! osiSockAttach () ) {
         throw S_cas_internal;
@@ -182,6 +186,25 @@ casDGIntfIO::casDGIntfIO ( caServerI & serverIn, clientBufMemoryManager & memMgr
             free ( pNode );
         }
     }
+#ifdef EPICS_HAS_CAS_IGNORE_NET_LIST
+    {
+        ELLLIST temp = ELLLIST_INIT;
+        size_t idx = 0;
+        osiSockNetNode *node;
+        networkList ( &temp, &EPICS_CAS_IGNORE_NET_LIST );
+        this->ignoreNets= new network_spec[1+ellCount(&temp)];
+
+        while((node=(osiSockNetNode*)ellGet(&temp))!=NULL)
+        {
+            (this->ignoreNets)[idx].addr= node->net.addr;
+            (this->ignoreNets)[idx].mask= node->net.mask;
+            idx++;
+            free(node);
+        }
+        (this->ignoreNets)[idx].addr= 0;
+        (this->ignoreNets)[idx].mask= 0;
+    }
+#endif
 
     //
     // Solaris specific:
@@ -268,6 +291,11 @@ casDGIntfIO::~casDGIntfIO()
         pEntry->~ipIgnoreEntry ();
         this->ipIgnoreEntryFreeList.release ( pEntry );
     }
+
+#ifdef EPICS_HAS_CAS_IGNORE_NET_LIST
+    if (this->ignoreNets)
+        free(this->ignoreNets);
+#endif
     
     osiSockRelease ();
 }
@@ -346,6 +374,20 @@ casDGIntfIO::osdRecv ( char * pBufIn, bufSizeT size,
                 }
             }
         }
+#ifdef EPICS_HAS_CAS_IGNORE_NET_LIST
+        if ( this->ignoreNets ) {
+            if ( addr.sa_family == AF_INET ) {
+                sockaddr_in * pIP = 
+                    reinterpret_cast < sockaddr_in * > ( & addr );
+                network_spec *spec= this->ignoreNets;
+                for(; spec->addr; spec++) {
+                    if ((pIP->sin_addr.s_addr & spec->mask)==(spec->addr & spec->mask))
+                        return casFillNone;
+                }
+            }
+        }
+#endif
+
         fromOut = addr;
         actualSize = static_cast < bufSizeT > ( status );
         return casFillProgress;

--- a/src/pcas/io/bsdSocket/casDGIntfIO.h
+++ b/src/pcas/io/bsdSocket/casDGIntfIO.h
@@ -11,8 +11,18 @@
 #ifndef casDGIntfIOh
 #define casDGIntfIOh
 
+#include <epicsVersion.h>
+
 #include "casDGClient.h"
 #include "ipIgnoreEntry.h"
+
+#ifdef EPICS_HAS_CAS_IGNORE_NET_LIST
+typedef struct
+  {
+    epicsUInt32 addr;
+    epicsUInt32 mask;
+  } network_spec;
+#endif
 
 class casDGIntfIO : public casDGClient {
 public:
@@ -43,6 +53,9 @@ public:
 private:
     tsFreeList < ipIgnoreEntry, 128 > ipIgnoreEntryFreeList;
     resTable < ipIgnoreEntry, ipIgnoreEntry > ignoreTable;
+#ifdef EPICS_HAS_CAS_IGNORE_NET_LIST
+    network_spec *ignoreNets;
+#endif
 	ELLLIST beaconAddrList;
 	SOCKET sock;
 	SOCKET bcastRecvSock; // fix for solaris bug


### PR DESCRIPTION
Pull Request for 2 features:

- Define networks to be ignored by servers with environment variable
  EPICS_CAS_IGNORE_NET_LIST
- Extend channel access security with IP access groups that define the IP
  address a client must have

This depends on similar patches to be applied to EPICS base.
