### PR TITLE
Make EPICS_CAS_BEACON_ADDR_LIST fall back to EPICS_CA_ADDR_LIST

### DIFF
--- a/src/pcas/io/bsdSocket/casDGIntfIO.cc
+++ b/src/pcas/io/bsdSocket/casDGIntfIO.cc
@@ -151,12 +151,18 @@ casDGIntfIO::casDGIntfIO ( caServerI & serverIn, clientBufMemoryManager & memMgr
         epicsSocketDestroy (this->sock);
         throw S_cas_bindFail;
     }
-    
-    if ( addConfigBeaconAddr ) {
-        addAddrToChannelAccessAddressList (
-            & BCastAddrList, &EPICS_CAS_BEACON_ADDR_LIST, beaconPort, 0 );
+
+    if (addConfigBeaconAddr) {
+        if (envGetConfigParamPtr ( & EPICS_CAS_BEACON_ADDR_LIST ) ) {
+            addAddrToChannelAccessAddressList (
+                & BCastAddrList, & EPICS_CAS_BEACON_ADDR_LIST, beaconPort, 0 );
+        }
+        else {
+            addAddrToChannelAccessAddressList (
+                & BCastAddrList, & EPICS_CA_ADDR_LIST, beaconPort, 0 );
+        }
     }
- 
+
     removeDuplicateAddresses ( & this->beaconAddrList, & BCastAddrList, 0 );
 
     {


### PR DESCRIPTION
This will allow "simple" configurations that only define EPICS_CA_ADDR_LIST and EPICS_CA_AUTO_ADDR_LIST=NO to get PCAS beacons sent to that configured audience. (instead of no beacons at all)

(fixes #7)