### PR TITLE
Allow a server to respond to a client with a specified protocol version

### DIFF
--- a/src/pcas/generic/casDGClient.cc
+++ b/src/pcas/generic/casDGClient.cc
@@ -344,7 +344,10 @@ caStatus casDGClient::searchResponse ( const caHdrLargeArray & msg,
     //
     if ( status == S_cas_success ) {
         AlignedWireRef < epicsUInt16 > tmp ( *pMinorVersion );
-        tmp = CA_MINOR_PROTOCOL_REVISION;
+        tmp = retVal.getMinorProtocol();
+        if ( ( tmp < 1 ) || ( tmp > CA_MINOR_PROTOCOL_REVISION ) ) {
+            tmp = CA_MINOR_PROTOCOL_REVISION;
+        }
         this->out.commitMsg ();
     }
 

--- a/src/pcas/generic/casdef.h
+++ b/src/pcas/generic/casdef.h
@@ -36,6 +36,7 @@
 #endif
 
 #include "caNetAddr.h"
+#include "caProto.h"
 #include "casEventMask.h"   // EPICS event select class 
 
 typedef aitUint32 caStatus;
@@ -119,16 +120,21 @@ public:
     pvExistReturn ( pvExistReturnEnum s = pverDoesNotExistHere );
     // directory service server tools will use this (see caNetAddr.h)
     pvExistReturn ( const caNetAddr & );
+    pvExistReturn ( const caNetAddr &, ca_uint16_t );
     ~pvExistReturn ();
     const pvExistReturn & operator = ( pvExistReturnEnum rhs );
     const pvExistReturn & operator = ( const caNetAddr & rhs );
     pvExistReturnEnum getStatus () const;
     caNetAddr getAddr () const;
     bool addrIsValid () const;
+    unsigned getMinorProtocol() const;
 private:
     caNetAddr address;
     pvExistReturnEnum status;
+    ca_uint16_t minorProtocolVersion;
 };
+
+#define HAS_CAS_RETURN_MINOR_PROTOCOL
 
 //
 // pvAttachReturn

--- a/src/pcas/generic/pvExistReturn.cc
+++ b/src/pcas/generic/pvExistReturn.cc
@@ -22,6 +22,11 @@ pvExistReturn::pvExistReturn ( pvExistReturnEnum s ) :
 pvExistReturn::pvExistReturn ( const caNetAddr & addrIn ) :
 	address ( addrIn ), status ( pverExistsHere ) {}
 
+pvExistReturn::pvExistReturn ( const caNetAddr & addrIn,
+                               ca_uint16_t minorProtoIn ) :
+	address ( addrIn ), status ( pverExistsHere ),
+	minorProtocolVersion(minorProtoIn) {}
+
 pvExistReturn::~pvExistReturn ()
 { 
 }
@@ -30,6 +35,7 @@ const pvExistReturn & pvExistReturn::operator = ( pvExistReturnEnum rhs )
 {
 	this->status = rhs;
 	this->address.clear ();
+  this->minorProtocolVersion= 0;
 	return * this;
 }
 
@@ -37,6 +43,7 @@ const pvExistReturn & pvExistReturn::operator = ( const caNetAddr & rhs )
 {
 	this->status = pverExistsHere;
 	this->address = rhs;
+  this->minorProtocolVersion = 0;
 	return * this;
 }
 
@@ -53,4 +60,9 @@ caNetAddr pvExistReturn::getAddr () const
 bool pvExistReturn::addrIsValid () const 
 { 
     return this->address.isValid (); 
+}
+
+unsigned pvExistReturn::getMinorProtocol () const 
+{ 
+    return this->minorProtocolVersion; 
 }


### PR DESCRIPTION
Adds a call to the PCAS API that allows the server to specify the protocol minor version number when responding to a pvExistTest. This is needed for the ca-nameserver to correctly report the protocol version of a server.